### PR TITLE
NTR - statehandler in payment plugin  updated to reopen

### DIFF
--- a/src/Service/ExamplePayment.php
+++ b/src/Service/ExamplePayment.php
@@ -72,7 +72,7 @@ class ExamplePayment implements AsynchronousPaymentHandlerInterface
             $this->transactionStateHandler->pay($transaction->getOrderTransaction()->getId(), $context);
         } else {
             // Payment not completed, set transaction status to "open"
-            $this->transactionStateHandler->open($transaction->getOrderTransaction()->getId(), $context);
+            $this->transactionStateHandler->reopen($transaction->getOrderTransaction()->getId(), $context);
         }
     }
 


### PR DESCRIPTION
### Description
The "open" Method of the StateHandler was renamed to "reopen"
- Fixed it in the plugin.